### PR TITLE
Fix library scan freeze during compatibility checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,9 @@ jobs:
 
       - name: Tests that need no network
         shell: bash
-        run: python test_reshade_ini.py
+        run: |
+          python test_reshade_ini.py
+          python -m unittest -v test_scan
 
       - name: Build
         run: |

--- a/core/dlss.py
+++ b/core/dlss.py
@@ -62,8 +62,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import time
 
-from . import remix
+from . import log, remix
 
 NATIVE, BRIDGE, FEEDER, OPTI, RENODX = "native", "bridge", "feeder", "optiscaler", "renodx"
 UPSTREAM = "upstream"
@@ -92,6 +93,8 @@ _SKIP_DIRS = {"content", "paks", "saved", "logs", "movies", "sounds", "music",
               "screenshots", "steamapps", "redist", "_commonredist", "host64",
               "reshade-shaders"}
 _WALK_DEPTH = 9
+_WALK_DIRS = 6000
+_WALK_SECONDS = 6.0
 
 # A game without DLSS may still ship AMD FSR 2/3 or Intel XeSS. OptiScaler
 # hooks those calls as its input ([Inputs] EnableFsr2Inputs / EnableFsr3Inputs
@@ -123,24 +126,31 @@ def find_dlss_files(folder: Path, skip_dir: Path | None = None,
     import os
     out: list[str] = []
     try:
-        base_depth = len(Path(folder).resolve().parts)
+        # Resolve the roots once. Resolving every directory (and skip_dir
+        # again for each one) made large engine trees take minutes on Windows.
+        folder = Path(folder).resolve()
+        skip_dir = Path(skip_dir).resolve() if skip_dir is not None else None
     except OSError:
         return out
-    for root, dirs, files in os.walk(folder):
+    base_depth = len(folder.parts)
+    deadline = time.monotonic() + _WALK_SECONDS
+    for seen, (root, dirs, files) in enumerate(os.walk(folder), 1):
+        # A depth limit and a match limit do not bound trees with thousands
+        # of directories and no runtime DLLs. Check even in the skipped root.
+        if seen > _WALK_DIRS or time.monotonic() >= deadline:
+            log.write(f"stopped looking for runtime DLLs under {folder} "
+                      f"after {seen - 1} folders - search budget reached", "warn")
+            break
         rp = Path(root)
-        depth = len(rp.resolve().parts) - base_depth if rp.exists() else 0
+        depth = len(rp.parts) - base_depth
         if depth >= _WALK_DEPTH:
             dirs[:] = []
         else:
             dirs[:] = [d for d in dirs if d.lower() not in _SKIP_DIRS
                        and d.lower() not in extra_skip
                        and not d.startswith(".")]
-        if skip_dir is not None:
-            try:
-                if rp.resolve() == Path(skip_dir).resolve():
-                    continue
-            except OSError:
-                pass
+        if rp == skip_dir:
+            continue
         for f in files:
             if f.lower() in names:
                 try:

--- a/core/games.py
+++ b/core/games.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from dataclasses import dataclass, field
 import pathlib
 from pathlib import Path
@@ -233,6 +234,12 @@ def scan_epic() -> list[Game]:
         try:
             d = json.loads(item.read_text(encoding="utf8", errors="replace"))
         except (OSError, json.JSONDecodeError):
+            continue
+        # Epic also registers engine plugins, content packs and Unreal
+        # Engine itself. A plugin's InstallLocation can be the entire engine
+        # tree (Quixel Bridge), which is both a false game and a huge scan.
+        # Older manifests without these flags still get inspected.
+        if d.get("bIsApplication") is False or d.get("bIsExecutable") is False:
             continue
         loc = d.get("InstallLocation")
         if not loc or not Path(loc).is_dir():
@@ -796,9 +803,12 @@ def scan_all(progress=None) -> list[Game]:
 
     total = len(games)
     for i, g in enumerate(games, 1):
-        if progress and (i % 5 == 0 or i == total):
-            progress(f"Inspecting games... {i}/{total}")
+        if progress:
+            progress(f"Inspecting games... {i}/{total}: {g.name}")
+        started = time.monotonic()
         enrich(g)
+        if time.monotonic() - started >= 1:
+            log.write(f"inspected {g.name} in {time.monotonic() - started:.1f}s")
     games.sort(key=lambda g: g.name.lower())
     return games
 

--- a/core/gui.py
+++ b/core/gui.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import queue
 import threading
+import time
 import traceback
 import webbrowser
 from pathlib import Path
@@ -1014,7 +1015,20 @@ class App:
         def work() -> None:
             try:
                 gs = games.scan_all(progress=lambda m: self.q.put(("scan", m)))
-                self.q.put(("scanned", gs))
+                # Compatibility checks walk folders too. Doing them in _fill
+                # blocked Tk just as it received the last scan messages, so
+                # the window stayed painted at e.g. 95/97 for minutes.
+                rows = {}
+                sm = self._sm()
+                for i, g in enumerate(gs, 1):
+                    if not g.exe:
+                        continue
+                    self.q.put(("scan", f"Checking compatibility... {i}/{len(gs)}: {g.name}"))
+                    started = time.monotonic()
+                    rows[(str(g.folder), str(g.exe))] = self._inspect_row(g, sm)
+                    if time.monotonic() - started >= 1:
+                        log.write(f"checked {g.name} in {time.monotonic() - started:.1f}s")
+                self.q.put(("scanned", (gs, rows)))
             except Exception:
                 log.exception("scanning the library")
                 self.q.put(("error", traceback.format_exc()))
@@ -1114,6 +1128,26 @@ class App:
             self.tree.see(kids[0])
 
     @staticmethod
+    def _inspect_row(g: games.Game, sm: int | None):
+        """Read the compatibility columns, normally on the scan worker."""
+        try:
+            ok, _ = installer.check_supported(g)
+            if not ok:
+                # A locked Xbox executable already has a useful error; a
+                # second search cannot make it readable.
+                return False, "-", installer.EXPERIMENTAL, "-", False, ""
+            sup = dlss.detect(g.install_dir, g.folder, g.api, g.bitness or 0, sm)
+            level, _ = installer.reliability(g, sup.recommended)
+            outlook = {installer.STABLE: "reliable",
+                       installer.BETA: "beta",
+                       installer.EXPERIMENTAL: "often fails"}[level]
+            ac = anticheat.detect(g.install_dir, g.folder)
+            return ok, sup.recommended, level, outlook, ac.present, ac.summary
+        except Exception as e:
+            log.exception(f"inspecting {g.name}", e)
+            return False
+
+    @staticmethod
     def _matches(g: games.Game, terms: list[str]) -> bool:
         """Every word typed has to appear - in the name, folder or store."""
         if not terms:
@@ -1141,23 +1175,9 @@ class App:
             key = (str(g.folder), str(g.exe))
             row = self._rows.get(key)
             if row is None:
-                # Each of these reads the game folder, so any one of them can
-                # fail on a folder that has gone away or become unreadable.
-                # Letting that escape would abandon the whole list half-drawn.
-                try:
-                    ok, _ = installer.check_supported(g)
-                    sup = dlss.detect(g.install_dir, g.folder, g.api,
-                                      g.bitness or 0, self._sm())
-                    level, _ = installer.reliability(g, sup.recommended)
-                    outlook = {installer.STABLE: "reliable",
-                               installer.BETA: "beta",
-                               installer.EXPERIMENTAL: "often fails"}[level]
-                    ac = anticheat.detect(g.install_dir, g.folder)
-                    row = (ok, sup.recommended, level, outlook,
-                           ac.present, ac.summary)
-                except Exception as e:
-                    log.exception(f"inspecting {g.name}", e)
-                    row = False
+                # Newly chosen folders and changed installs need fresh rows;
+                # the library scan supplies its rows before asking Tk to fill.
+                row = self._inspect_row(g, self._sm())
                 self._rows[key] = row
             if row is False:
                 self.tree.insert("", "end", iid=str(i), text="  " + g.name,
@@ -2402,6 +2422,7 @@ class App:
                     self.scanlbl.config(text=payload.lower())
                     self.status.config(text=payload.lower())
                 elif kind == "scanned":
+                    payload, rows = payload
                     self.busy = False
                     # A folder chosen while the scan was still running used
                     # to vanish when the scan finished (issue #18).
@@ -2414,6 +2435,7 @@ class App:
                                       for x in payload):
                         self.all_games.insert(0, kp)
                     self._rows.clear()
+                    self._rows.update(rows)
                     self._fill()
                     self.status.config(text="scan complete")
                     self._check_stale()

--- a/test_scan.py
+++ b/test_scan.py
@@ -1,0 +1,223 @@
+"""Offline scan regressions: python -m unittest -v test_scan."""
+import json
+import queue
+import tempfile
+import threading
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from core import dlss, games, gui, installer, log
+
+
+class ScanTests(unittest.TestCase):
+    def setUp(self):
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        self.temp = tempfile.TemporaryDirectory(prefix="autopilot_scan_")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.logs = self.stack.enter_context(patch.object(log, "write"))
+
+    def test_epic_ignores_non_applications_but_keeps_older_manifests(self):
+        manifests = self.root / "Epic/EpicGamesLauncher/Data/Manifests"
+        manifests.mkdir(parents=True)
+        entries = (
+            ("Quixel Bridge", False, False),
+            ("Unreal Engine", False, True),
+            ("Content pack", True, False),
+            ("Game", True, True),
+            ("Older game", None, None),
+        )
+        for i, (name, application, executable) in enumerate(entries):
+            folder = self.root / name
+            folder.mkdir()
+            (folder / "Game.exe").touch()
+            data = {"DisplayName": name, "InstallLocation": str(folder),
+                    "LaunchExecutable": "Game.exe"}
+            if application is not None:
+                data.update(bIsApplication=application, bIsExecutable=executable)
+            (manifests / f"{i}.item").write_text(json.dumps(data), encoding="utf8")
+        with patch.dict("os.environ", {"PROGRAMDATA": str(self.root)}):
+            found = games.scan_epic()
+        self.assertEqual({g.name for g in found}, {"Game", "Older game"})
+        self.assertTrue(all(g.exe.name == "Game.exe" for g in found))
+
+    def test_progress_identifies_every_game_including_last_two(self):
+        found = [games.Game(f"Game {i}", self.root / str(i)) for i in range(1, 98)]
+        messages = []
+        with ExitStack() as stack:
+            for name in ("steam", "epic", "gog", "ea", "ubisoft", "battlenet",
+                         "rockstar", "amazon", "itch", "heroic", "xbox", "folders",
+                         "emulators"):
+                stack.enter_context(patch.object(
+                    games, f"scan_{name}", return_value=found if name == "steam" else []))
+            enrich = stack.enter_context(patch.object(games, "enrich", side_effect=lambda g: g))
+            result = games.scan_all(messages.append)
+        self.assertEqual(len(result), 97)
+        self.assertEqual(enrich.call_count, 97)
+        inspecting = [m for m in messages if m.startswith("Inspecting games")]
+        self.assertEqual(len(inspecting), 97)
+        self.assertEqual(inspecting[-2:], ["Inspecting games... 96/97: Game 96",
+                                          "Inspecting games... 97/97: Game 97"])
+
+    def test_runtime_walk_keeps_nested_evidence_and_excludes_our_runtime(self):
+        (self.root / "nvngx_dlss.dll").touch()
+        engine = self.root / "Engine/Plugins/Runtime/Nvidia/DLSS/Binaries/ThirdParty/Win64"
+        engine.mkdir(parents=True)
+        runtime = engine / "NVNGX_DLSS.DLL"
+        runtime.touch()
+        # Content trees are deliberately pruned even if they contain a match.
+        (self.root / "Content").mkdir()
+        (self.root / "Content/nvngx_dlss.dll").touch()
+        found = dlss.find_dlss_files(self.root, skip_dir=self.root)
+        self.assertEqual(found, [str(runtime.relative_to(self.root))])
+
+    def test_upscaler_walk_excludes_optiscalers_bundled_files(self):
+        (self.root / "OptiScaler").mkdir()
+        (self.root / "OptiScaler/libxess.dll").touch()
+        (self.root / "bin").mkdir()
+        runtime = self.root / "bin/ffx_fsr2_api_x64.dll"
+        runtime.touch()
+        found = dlss.find_upscaler_files(self.root, skip_dir=self.root)
+        self.assertEqual(found, [str(runtime.relative_to(self.root))])
+
+    def test_runtime_walk_stops_without_matches(self):
+        visited = []
+
+        def wide_tree(_folder):
+            for i in range(100):
+                visited.append(i)
+                yield str(self.root / str(i)), [], []
+
+        with patch("os.walk", side_effect=wide_tree), patch.object(dlss, "_WALK_DIRS", 3):
+            self.assertEqual(dlss.find_dlss_files(self.root), [])
+        self.assertEqual(len(visited), 4)
+        self.assertIn("search budget reached", self.logs.call_args.args[0])
+
+    def test_runtime_deadline_applies_even_when_install_folder_is_skipped(self):
+        tree = [(str(self.root), ["bin"], []),
+                (str(self.root / "bin"), [], ["nvngx_dlss.dll"])]
+        with patch("os.walk", return_value=iter(tree)), \
+                patch.object(dlss.time, "monotonic", side_effect=[0, 0, 10]):
+            self.assertEqual(dlss.find_dlss_files(self.root, skip_dir=self.root), [])
+        self.assertIn("search budget reached", self.logs.call_args.args[0])
+
+    def test_runtime_budget_keeps_evidence_already_found(self):
+        tree = [(str(self.root), [], ["nvngx_dlss.dll"]),
+                (str(self.root / "bin"), [], ["nvngx_dlssg.dll"])]
+        with patch("os.walk", return_value=iter(tree)), patch.object(dlss, "_WALK_DIRS", 1):
+            self.assertEqual(dlss.find_dlss_files(self.root), ["nvngx_dlss.dll"])
+
+    def test_runtime_walk_resolves_roots_only(self):
+        for i in range(10):
+            (self.root / str(i)).mkdir()
+        resolve = Path.resolve
+        with patch.object(Path, "resolve", autospec=True, side_effect=resolve) as resolved:
+            dlss.find_dlss_files(self.root, skip_dir=self.root)
+        self.assertEqual(resolved.call_count, 2)
+
+    def make_app(self):
+        # Exercise the real worker, queue pump and row rendering without a
+        # display, hardware probes, downloads or the user's settings.
+        app = gui.App.__new__(gui.App)
+        app.q = queue.Queue()
+        app.root = Mock()
+        app.busy = False
+        app._rows = {}
+        app._fill_job = None
+        app._crash_shown = False
+        app.all_games = []
+        app.stale = {}
+        app.step = 2
+        app.arch = Mock(get=Mock(return_value="all"))
+        app.search = Mock(get=Mock(return_value=""))
+        app.only_installed = None
+        app.tree = Mock(get_children=Mock(return_value=()))
+        app.scanlbl = Mock()
+        app.btn_next = Mock()
+        app.status = Mock()
+        app.detail = Mock()
+        app._sm = Mock(return_value=120)
+        app._check_stale = Mock()
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(patch.object(gui.video, "known", return_value=None))
+        stack.enter_context(patch.object(log, "crashed", return_value=False))
+        return app
+
+    def test_scan_checks_compatibility_off_ui_thread_and_renders_cached_rows(self):
+        app = self.make_app()
+        game = games.Game("Game", self.root, exe=self.root / "Game.exe",
+                          bitness=64, api="DX12")
+        entered, release = threading.Event(), threading.Event()
+        ui_thread = threading.get_ident()
+        worker_ids = []
+        workers = []
+        thread_class = threading.Thread
+
+        def thread_factory(*args, **kwargs):
+            thread = thread_class(*args, **kwargs)
+            workers.append(thread)
+            return thread
+
+        def slow_detect(*_args):
+            worker_ids.append(threading.get_ident())
+            entered.set()
+            if not release.wait(5):
+                raise AssertionError("test did not release the detector")
+            return dlss.Support(recommended=dlss.FEEDER)
+
+        with patch.object(games, "scan_all", return_value=[game]), \
+                patch.object(gui.threading, "Thread", side_effect=thread_factory), \
+                patch.object(dlss, "detect", side_effect=slow_detect) as detect:
+            try:
+                app._scan()
+                self.assertTrue(entered.wait(2))
+                # Tk can still pump progress while detection is blocked.
+                app._pump()
+                self.assertTrue(app.busy)
+                app.scanlbl.config.assert_called_with(text="checking compatibility... 1/1: game")
+            finally:
+                release.set()
+                for worker in workers:
+                    worker.join(5)
+            self.assertTrue(all(not worker.is_alive() for worker in workers))
+            app._pump()
+            app._fill()  # Filtering/refilling must use the same prepared rows.
+            self.assertEqual(detect.call_count, 1)
+        self.assertEqual(len(worker_ids), 1)
+        self.assertNotEqual(worker_ids[0], ui_thread)
+        self.assertFalse(app.busy)
+        self.assertEqual(app.shown, [game])
+        self.assertEqual(app.tree.insert.call_args.kwargs["values"][-1], "ready")
+        app.status.config.assert_called_with(text="scan complete")
+
+    def test_unreadable_games_do_not_trigger_another_folder_search(self):
+        g = games.Game("Locked game", self.root, exe=self.root / "Game.exe",
+                       error=games.XBOX_HINT)
+        with patch.object(dlss, "detect") as detect:
+            row = gui.App._inspect_row(g, 120)
+        detect.assert_not_called()
+        self.assertFalse(row[0])
+        self.assertEqual(installer.check_supported(g), (False, games.XBOX_HINT))
+
+    def test_row_failure_does_not_discard_other_scan_results_or_manual_games(self):
+        app = self.make_app()
+        bad = games.Game("Unreadable", self.root, exe=self.root / "Bad.exe", bitness=64)
+        manual = games.Game("Chosen folder", self.root / "manual", exe=self.root / "manual/Game.exe")
+        app.all_games = [manual]
+        with patch.object(dlss, "detect", side_effect=OSError("drive removed")), \
+                patch.object(log, "exception"):
+            failed_row = gui.App._inspect_row(bad, 120)
+        app.q.put(("scanned", ([bad], {(str(bad.folder), str(bad.exe)): failed_row})))
+        app._pump()
+        self.assertEqual(app.all_games, [manual, bad])
+        self.assertEqual(app.tree.insert.call_count, 2)
+        self.assertEqual(app.tree.insert.call_args.kwargs["values"][-1], "unreadable")
+        self.assertFalse(app.busy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I ran into an issue where library scanning would appear to hang near completion. In my case, Epic’s Quixel Bridge plugin was being detected as a game, which caused compatibility checks to search through the Unreal Engine install on the UI thread.

This PR:

* Filters out Epic entries marked as non-applications/non-executables
* Bounds runtime searches and moves compatibility preparation off the UI thread
* Shows the current game being processed
* Adds regression coverage for the scan behavior

On my machine, both 64-bit scan modes would stop at `95/97` until the process was killed. With these changes, the same library completes scanning and list preparation in about 15 seconds.

Validation: 11 scan regression tests and the existing INI tests pass.

### Before

<img width="532" height="400" alt="Screenshot 2026-09-06 133122" src="https://github.com/user-attachments/assets/e080c8c0-d2a6-4954-bd0c-b5bb4e712143" />

### Updated progress reporting

<img width="663" height="360" alt="Screenshot 2026-09-06 133655" src="https://github.com/user-attachments/assets/2534bcce-17f8-4e65-a1a8-679a42283d4e" />
