### PR TITLE
fix: handle protected Xbox executables separately from write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,12 @@ antivirus or VPN inside the HTTPS connection; turn that off for the tool.
 Not every launcher is in the registry, and an executable locked at scan
 time (antivirus, an updater, OneDrive placeholders) cannot be read.
 **open log file** shows what each store returned; **choose folder** always
-works. Xbox/Game Pass: only games whose publisher allows modding show
-*Manage > Files > Browse* (or *Enable mods*) in the Xbox app - use it and
-rescan; without it the folder cannot be modified by anything, and the
-Steam version can.
+works. Xbox/Game Pass can protect the executable while allowing files beside
+it. For a protected EXE, choose **architecture** in the game details and
+check **graphics api** (both choices are remembered for that folder). The
+protection warning stays visible; installation still tests actual directory
+write access and stops if Windows refuses it. No ownership or ACL changes
+are made. An Xbox app "Enable mods" toggle is not required or assumed.
 </details>
 
 <details>

--- a/core/games.py
+++ b/core/games.py
@@ -37,14 +37,14 @@ def _isdir(p) -> bool:
     except OSError:
         return False
 
-# What to tell someone whose Xbox / Game Pass game we cannot even read.
-# One sentence, shared with the installer so both places say the same thing.
-XBOX_HINT = ("Windows keeps this Store/Game Pass folder locked. Only games "
-             "whose publisher allows modding show 'Manage > Files > Browse' "
-             "(or 'Enable mods') in the Xbox app; if that entry is there, "
-             "use it and rescan. If it is not - Microsoft Flight Simulator, "
-             "most Store titles - the folder cannot be modified by anything, "
-             "and the Steam version of the game is the one that can be.")
+XBOX_HINT = ("Windows does not allow creating and removing the files needed "
+             "for the mod in this Xbox / Game Pass install directory. "
+             "Executable protection and directory write access are separate; "
+             "installation cannot continue here.")
+XBOX_EXE_HINT = ("Executable header cannot be read because this Xbox title "
+                 "protects the EXE. Architecture must be set by hand; graphics "
+                 "API evidence comes from other files or your override. "
+                 "The installer still checks directory write access.")
 
 # Folder names Windows keeps under its own ownership for store games. Exact
 # segment match on purpose: ModifiableWindowsApps is the one that IS meant
@@ -55,9 +55,7 @@ _LOCKED_STORE_DIRS = ("xboxgames", "windowsapps")
 def is_locked_store_path(path: Path) -> bool:
     r"""Is this path inside C:\XboxGames or a WindowsApps folder?
 
-    Says nothing about whether it is readable - a game that has had "Enable
-    mods" applied stays under XboxGames and works fine. It only tells the
-    caller that a permission failure here has a known, non-admin fix.
+    Says nothing about read or write access; callers must probe separately.
     """
     try:
         parts = Path(path).parts
@@ -67,24 +65,15 @@ def is_locked_store_path(path: Path) -> bool:
 
 
 def _xbox_locked(g: "Game") -> bool:
-    r"""Sets the Enable-mods error when a store-owned executable is unreadable.
-
-    Game Pass installs under C:\XboxGames\<Game>\Content belong to the system:
-    a normal user cannot open the exe for reading, so every scan logged
-    "Permission denied" as a warning and the game showed a cryptic header
-    error. The fix is a switch in the Xbox app, not "run as administrator",
-    and taking ownership of the folder for the person is not our business.
-    os.access() is not used because on Windows it only looks at the read-only
-    attribute, not the ACL that is actually in the way.
-    """
+    """Warn about EXE protection without inferring directory write access."""
     if g.exe is None or not is_locked_store_path(g.exe):
         return False
     try:
         with open(g.exe, "rb") as f:
             f.read(1)
     except PermissionError:
-        g.error = XBOX_HINT
-        log.write(f"{g.name}: {g.exe} is not readable yet - {XBOX_HINT}")
+        g.exe_warning = XBOX_EXE_HINT
+        log.write(f"{g.name}: {g.exe} is protected - {XBOX_EXE_HINT}")
         return True
     except OSError:
         return False
@@ -106,6 +95,7 @@ class Game:
     emu: object | None = None    # emulators.Profile, when applicable
     install_root: Path | None = None   # folder an earlier install wrote to
     kind: str = "game"             # "game" or "video" (a player, no depth)
+    exe_warning: str = ""          # protected Xbox EXE; not a write-access verdict
 
     @property
     def install_dir(self) -> Path:
@@ -458,15 +448,8 @@ XBOX_NOT_GAMES = {"gamesave", "minecraft launcher"}
 def scan_xbox() -> list[Game]:
     r"""Xbox / Game Pass.
 
-    Only ModifiableWindowsApps is readable and writable; the protected
-    WindowsApps copy cannot be modified at all, so listing it would offer
-    installs that can never work.
-
-    XboxGames is listed even though its Content folders are system-owned
-    until the person flips "Enable mods" in the Xbox app: `enrich` turns the
-    resulting permission error into that instruction, and after the switch
-    (or when the game moved to a folder of their choosing) the same entry
-    reads and installs like any other.
+    Discover the usual library folders. Executable read access is checked
+    by enrich(); directory write access is checked by installer.preflight().
     """
     out: list[Game] = []
     roots = []
@@ -759,6 +742,30 @@ def set_api_override(folder: Path, api: str | None) -> None:
     prefs.set_("api_override", d)
 
 
+def bitness_override(folder: Path) -> int | None:
+    """Architecture chosen for a protected Xbox executable, or None."""
+    from . import prefs
+    try:
+        value = (prefs.get("bitness_override") or {}).get(str(folder).lower())
+        return value if type(value) is int and value in (32, 64) else None
+    except (AttributeError, TypeError):
+        return None
+
+
+def set_bitness_override(folder: Path, bitness: int | None) -> None:
+    """Remember an explicit architecture; None restores automatic detection."""
+    if bitness is not None and (type(bitness) is not int or bitness not in (32, 64)):
+        raise ValueError("Architecture must be 32 or 64.")
+    from . import prefs
+    d = dict(prefs.get("bitness_override") or {})
+    key = str(folder).lower()
+    if bitness is None:
+        d.pop(key, None)
+    else:
+        d[key] = bitness
+    prefs.set_("bitness_override", d)
+
+
 def enrich(g: Game, chosen: bool = False) -> Game:
     """Pick the executable and detect its architecture / graphics API.
 
@@ -769,6 +776,9 @@ def enrich(g: Game, chosen: bool = False) -> Game:
     """
     if chosen:
         g.install_root = None
+    g.error = g.exe_warning = ""
+    g.bitness = None
+    g.api, g.api_why, g.api_detected = "?", "", ""
     try:
         if g.exe is None or not g.exe.is_file():
             cands = pe.find_game_exes(g.folder)
@@ -784,10 +794,9 @@ def enrich(g: Game, chosen: bool = False) -> Game:
             _prefer_real_exe(g)
             adopt_previous_install(g)
         if _xbox_locked(g):
-            # Keep the game in the list with its executable, so the detail
-            # card can show the fix; there is nothing else to read here.
-            return g
-        g.bitness = pe.exe_bitness(g.exe)
+            g.bitness = bitness_override(g.folder)
+        else:
+            g.bitness = pe.exe_bitness(g.exe)
         g.api, g.api_why = pe.detect_api(g.exe)
         g.api_detected = g.api
         forced = api_override(g.folder)
@@ -884,7 +893,7 @@ def same_exe_once(games: list) -> list:
         # install recorded against it, or a graphics API set by hand - both
         # are keyed by that entry's folder and would be lost with it.
         try:
-            forced = bool(api_override(g.folder))
+            forced = bool(api_override(g.folder) or bitness_override(g.folder))
         except Exception:
             forced = False
         return (bool(getattr(g, "installed", False)), forced)

--- a/core/gui.py
+++ b/core/gui.py
@@ -708,9 +708,7 @@ class App:
         self._jump(2 if self._have_library() else 1)
 
     def _can_install_page(self) -> bool:
-        """A game is picked, and one the tool can set up: 'continue' is off
-        for an Xbox game without mods enabled, and the rail must not be the
-        way round it."""
+        """A game is picked and has the metadata needed to install."""
         if not self.game:
             return False
         try:
@@ -1130,6 +1128,21 @@ class App:
                                bg=PANEL, fg=FAINT, font=font(9),
                                anchor="w", justify="left")
         self.detail.pack(fill="x")
+        self.protected_details = tk.Frame(det.inner, bg=PANEL)
+        tk.Label(self.protected_details, text=games.XBOX_EXE_HINT, bg=PANEL,
+                 fg=RUST, font=font(9), anchor="w", justify="left",
+                 wraplength=px(800)).pack(fill="x", pady=(6, 0))
+        choices = tk.Frame(self.protected_details, bg=PANEL)
+        choices.pack(anchor="w", pady=(6, 0))
+        ttk.Label(choices, text="architecture").pack(side="left")
+        self.cb_bitness = ttk.Combobox(choices, state="readonly", width=31,
+                                      values=["auto - protected EXE", "64-bit", "32-bit"])
+        self.cb_bitness.pack(side="left", padx=(8, 16))
+        self.cb_bitness.bind("<<ComboboxSelected>>", self._on_bitness)
+        ttk.Label(choices, text="graphics api").pack(side="left")
+        self.cb_protected_api = ttk.Combobox(choices, state="readonly", width=25)
+        self.cb_protected_api.pack(side="left", padx=(8, 0))
+        self.cb_protected_api.bind("<<ComboboxSelected>>", self._on_api)
         return f
 
     def _pick_folder(self) -> None:
@@ -1779,8 +1792,7 @@ class App:
         try:
             ok, _ = installer.check_supported(g)
             if not ok:
-                # A locked Xbox executable already has a useful error; a
-                # second search cannot make it readable.
+                # Missing metadata or a fatal scan error: show its reason.
                 return False, "-", installer.EXPERIMENTAL, "-", False, ""
             sup = dlss.detect(g.install_dir, g.folder, g.api, g.bitness or 0, sm)
             level, _ = installer.reliability(g, sup.recommended)
@@ -1841,7 +1853,8 @@ class App:
                 continue
             ok, route, level, outlook, ac_present, ac_summary = row
             if not ok:
-                status, tag, outlook = "unsupported", "unsupported", "-"
+                status = "needs metadata" if g.exe_warning and not g.error else "unsupported"
+                tag, outlook = "unsupported", "-"
             elif ac_present:
                 # Not refused - it is their machine - but said up front, and
                 # asked again before INSTALL.
@@ -1904,6 +1917,7 @@ class App:
                        "store returned")
         self.scanlbl.config(text=msg)
         self.game = None
+        self.protected_details.pack_forget()
         self.detail.config(text="select a game for details", fg=FAINT)
         self.btn_next.config(state="disabled")
         self._paint_rail()
@@ -1918,6 +1932,13 @@ class App:
         self.game = g
         self._paint_rail()
         ok, why = installer.check_supported(g)
+        self.protected_details.pack_forget()
+        if g.exe_warning:
+            self.cb_bitness.current({64: 1, 32: 2}.get(g.bitness, 0))
+            self.cb_protected_api["values"] = [f"auto - {g.api_detected}"] + list(games.APIS)
+            forced = games.api_override(g.folder)
+            self.cb_protected_api.current(games.APIS.index(forced) + 1 if forced in games.APIS else 0)
+            self.protected_details.pack(fill="x")
         sup = dlss.detect(g.install_dir, g.folder, g.api, g.bitness or 0, self._sm())
         level, why_rel = installer.reliability(g, sup.recommended)
         proxy = installer._proxy_name(g.api, self._opts().reshade_proxy)
@@ -2987,6 +3008,8 @@ class App:
         self.route = path
         usable, note = self.route_fit.get(path, (True, ""))
         parts: list[tuple[str, str]] = []
+        if self.game and self.game.exe_warning:
+            parts.append(("warn", self.game.exe_warning))
         if not usable:
             parts.append(("bad", f"NOT FOR THIS PC - {note}."))
         parts.append(("blurb", dlss.BLURB[path]))
@@ -3343,10 +3366,10 @@ class App:
         g = self.game
         if not g or not hasattr(self, "cb_api"):
             return
-        i = self.cb_api.current()
+        cb = _e.widget if _e is not None else self.cb_api
+        i = cb.current()
         chosen = "" if i <= 0 else games.APIS[i - 1]
         games.set_api_override(g.folder, chosen or None)
-        self.root.after(1, self._remember_library)
         detected = getattr(g, "api_detected", "") or g.api
         if chosen:
             g.api, g.api_why = chosen, f"set by hand (detected {detected})"
@@ -3359,14 +3382,37 @@ class App:
             except Exception:
                 g.api, g.api_why = detected, "detected from the executable"
         self._log(f"> graphics api: {g.api}" + ("" if chosen else " (auto)"))
+        if cb is self.cb_protected_api:
+            self._refresh_metadata()
+            return
+        self.root.after(1, self._remember_library)
+        self._forget_row(g)
         self._enter_install()
+
+    def _on_bitness(self, _e=None) -> None:
+        if not self.game or not self.game.exe_warning:
+            return
+        chosen = {1: 64, 2: 32}.get(self.cb_bitness.current())
+        games.set_bitness_override(self.game.folder, chosen)
+        self.game.bitness = chosen
+        self._refresh_metadata()
+
+    def _refresh_metadata(self) -> None:
+        g = self.game
+        self._forget_row(g)
+        self._fill()
+        if g in self.shown:
+            self.tree.selection_set(str(self.shown.index(g)))
+            self._on_pick()
+        self._remember_library()
 
     def _enter_install(self) -> None:
         g = self.game
         self.gamelbl.config(text=g.name)
         if getattr(g, "kind", "") != "video":
             detected = getattr(g, "api_detected", "") or g.api
-            self.cb_api["values"] = [f"auto  -  {detected} from the executable"] + \
+            origin = "other files (protected EXE)" if g.exe_warning else "the executable"
+            self.cb_api["values"] = [f"auto  -  {detected} from {origin}"] + \
                 [{"DX9": "DirectX 9", "DX10": "DirectX 10", "DX11": "DirectX 11",
                   "DX12": "DirectX 12"}.get(a, a) for a in games.APIS]
             forced = games.api_override(g.folder)
@@ -3800,7 +3846,7 @@ class App:
             self._show(2)
             self._enter_library(asked=True)
         elif self.step == 2:
-            if not self.game:
+            if not self._can_install_page():
                 return
             self._show(3)
             self._enter_install()

--- a/core/installer.py
+++ b/core/installer.py
@@ -41,6 +41,7 @@ import json
 import os
 import shutil
 import struct
+import tempfile
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -489,10 +490,10 @@ def check_supported(g: games.Game) -> tuple[bool, str]:
     if not g.exe:
         return False, "No game executable found."
     if g.error:
-        # The scan already knows why this one cannot be set up (an Xbox game
-        # that has not had "Enable mods" yet, an unreadable header). The GUI
-        # shows this reason in the detail card, so it must come from here.
         return False, g.error
+    if g.exe_warning and (g.bitness not in (32, 64) or g.api not in games.APIS):
+        return False, ("Protected Xbox executable: select its architecture and "
+                       "graphics API in the game details before continuing.")
     if g.bitness not in (32, 64):
         return False, "Could not read the architecture."
     if g.api == "Vulkan":
@@ -901,6 +902,8 @@ def preview(g: games.Game, opt: Options) -> Preview:
     """
     pv = Preview()
     root = g.install_dir
+    if g.exe_warning:
+        pv.warnings.append(g.exe_warning)
 
     ok, why = check_supported(g)
     if not ok:
@@ -1802,17 +1805,15 @@ def preflight(g: games.Game) -> None:
     if not games._isdir(root):
         raise InstallError(f"{root} does not exist.")
 
-    probe = root / ".dlss5-autopilot-write-test"
     try:
-        probe.write_bytes(b"x")
-        probe.unlink()
-    except PermissionError:
+        with tempfile.NamedTemporaryFile(prefix=".dlss5-autopilot-write-test-",
+                                         dir=root) as probe:
+            probe.write(b"x")
+    except PermissionError as e:
         if games.is_locked_store_path(root):
-            # Xbox / Game Pass: the folder is owned by the system, and
-            # elevation does not help - the Xbox app has the switch for it.
             raise InstallError(
-                f"No permission to write into:\n{root}\n\n"
-                f"This is an Xbox / Game Pass game. {games.XBOX_HINT}") from None
+                f"Cannot create/remove a temporary file in:\n{root}\n\n"
+                f"{games.XBOX_HINT}\n\n{e}") from None
         raise InstallError(
             f"No permission to write into:\n{root}\n\n"
             f"Close the game if it is running, then try again. If that is not "

--- a/core/library.py
+++ b/core/library.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 from . import prefs
 
-SCHEMA = 1
+SCHEMA = 2
 # Beside settings.json in %LOCALAPPDATA%, not beside the executable: the
 # exe is run from Downloads, from a USB stick, from a folder Defender
 # has taken an interest in - none of them a place to keep state.
@@ -73,6 +73,7 @@ def _to_json(g) -> dict:
         "source": g.source,
         "candidates": [str(c) for c in (g.candidates or [])],
         "error": g.error,
+        "exe_warning": g.exe_warning,
         "install_root": str(g.install_root) if g.install_root else None,
         "kind": g.kind,
         "stamp": _stamp(g),
@@ -93,9 +94,13 @@ def _from_json(d: dict):
         source=d.get("source") or "Manual",
         candidates=[Path(c) for c in d.get("candidates") or []],
         error=d.get("error") or "",
+        exe_warning=d.get("exe_warning") or "",
         install_root=Path(d["install_root"]) if d.get("install_root") else None,
         kind=d.get("kind") or "game",
     )
+    if g.exe_warning:
+        g.bitness = games.bitness_override(g.folder)
+        g.api = g.api_detected or "?"
     # A graphics API set by hand on the install page lives in the settings,
     # not in the library, and it has to win here exactly as it wins in
     # games.enrich(): a cached game that came back with its DETECTED renderer
@@ -171,7 +176,9 @@ def load(version: str, sm) -> tuple[list, dict, list] | None:
             if not g.folder.exists():
                 continue                      # the game (or its drive) is gone
             out.append(g)
-            if _stamp(g) != [list(x) if x else None for x in (d.get("stamp") or [])]:
+            # Protection can change without an EXE timestamp change; also
+            # recheck manual metadata rather than reuse a compatibility row.
+            if g.exe_warning or _stamp(g) != [list(x) if x else None for x in (d.get("stamp") or [])]:
                 changed.append(g)             # changed on disk: read it again
                 continue
             r = raw.get(_key(g))

--- a/test_all.py
+++ b/test_all.py
@@ -5,6 +5,7 @@ Run this before cutting a release.
 """
 import inspect
 import json
+import os
 import shutil
 import ssl
 import subprocess
@@ -13,6 +14,7 @@ import tempfile
 import time
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 try:
@@ -21,7 +23,8 @@ except Exception:
     pass
 
 FAILS: list[str] = []
-X64 = Path(r"C:\Users\Mustafa\Downloads\dlss5-feed-host64.exe")
+X64 = Path(os.environ.get("DLSS5_TEST_X64",
+                          r"C:\Users\Mustafa\Downloads\dlss5-feed-host64.exe"))
 SRC_DIR = Path(__file__).resolve().parent
 
 
@@ -1337,7 +1340,7 @@ check("ModifiableWindowsApps is not",
       not games.is_locked_store_path(Path(r"C:\Program Files\ModifiableWindowsApps\X")))
 check("a plain folder is not", not games.is_locked_store_path(Path(r"D:\Games\X")))
 
-# A readable game under XboxGames (after Enable mods) is a normal game.
+# A readable game under XboxGames is a normal game.
 _d = Path(tempfile.mkdtemp(prefix="xbox_ok_"))
 _content = _d / "XboxGames" / "Fake" / "Content"
 _content.mkdir(parents=True)
@@ -1350,37 +1353,13 @@ check("...and is supported", installer.check_supported(_g)[0])
 shutil.rmtree(_d, ignore_errors=True)
 
 
-def _deny_read(exe: Path) -> bool:
-    """Take the current user's read right away with icacls; False if that
-    cannot be done here (no icacls, elevated token that ignores it, ...)."""
-    if not _os.environ.get("USERNAME"):
-        return False
-    try:
-        who = subprocess.run(["whoami"], capture_output=True, text=True,
-                             timeout=15).stdout.strip() or _os.environ["USERNAME"]
-        # (RD) only: a full (R) deny also takes READ_CONTROL away, after
-        # which icacls itself can no longer read the ACL to undo it.
-        r = subprocess.run(["icacls", str(exe), "/deny", f"{who}:(RD)"],
-                           capture_output=True, text=True, timeout=15)
-        if r.returncode != 0:
-            return False
-        with open(exe, "rb") as f:
-            f.read(1)
-        return False    # the deny did not bite - do not test on top of it
-    except PermissionError:
-        return True
-    except Exception:
-        return False
+_real_open = open
 
 
-def _allow_read(exe: Path) -> None:
-    try:
-        who = subprocess.run(["whoami"], capture_output=True, text=True,
-                             timeout=15).stdout.strip() or _os.environ.get("USERNAME", "")
-        subprocess.run(["icacls", str(exe), "/remove:d", who],
-                       capture_output=True, text=True, timeout=15)
-    except Exception:
-        pass
+def _protected_read(path, mode="r", *args, **kwargs):
+    if Path(path) == _exe and mode == "rb":
+        raise PermissionError(13, "Permission denied", str(path))
+    return _real_open(path, mode, *args, **kwargs)
 
 
 # The real failure: an exe under XboxGames the user cannot read.
@@ -1389,24 +1368,17 @@ _content = _d / "XboxGames" / "Fake" / "Content"
 _content.mkdir(parents=True)
 _exe = _content / "Game.exe"
 shutil.copyfile(X64, _exe)
-if _deny_read(_exe):
-    try:
-        _g = games.manual(_content)
-        check("an unreadable XboxGames exe gets the Enable-mods sentence",
-              _g.error == games.XBOX_HINT, repr(_g.error))
-        check("...the game keeps its executable so it stays listed",
-              _g.exe == _exe)
-        _ok, _why = installer.check_supported(_g)
-        check("...and check_supported hands that sentence to the GUI",
-              not _ok and _why == games.XBOX_HINT, repr(_why))
-        # preflight on the real denied folder: writing next to the exe is
-        # allowed here (only the file's read was denied), so use the
-        # monkeypatch below for the write failure instead.
-    finally:
-        _allow_read(_exe)
-    check("read right restored", _exe.read_bytes()[:2] == b"MZ")
-else:
-    check("icacls deny not available here - unreadable-exe checks skipped", True)
+with patch("builtins.open", side_effect=_protected_read):
+    _g = games.manual(_content)
+    check("an unreadable XboxGames exe gets a warning, not a fatal error",
+          not _g.error and _g.exe_warning == games.XBOX_EXE_HINT, repr(_g.exe_warning))
+    check("...the game keeps its executable so it stays listed", _g.exe == _exe)
+    _ok, _why = installer.check_supported(_g)
+    check("...and check_supported requests missing metadata",
+          not _ok and "select its architecture and graphics API" in _why, repr(_why))
+    installer.preflight(_g)
+    check("writing beside a protected EXE is allowed", True)
+check("the executable was not changed", _exe.read_bytes()[:2] == b"MZ")
 shutil.rmtree(_d, ignore_errors=True)
 
 # The same unreadable exe outside a store folder keeps the plain error: the
@@ -1415,19 +1387,14 @@ shutil.rmtree(_d, ignore_errors=True)
 _d = Path(tempfile.mkdtemp(prefix="plain_locked_"))
 _exe = _d / "Game.exe"
 shutil.copyfile(X64, _exe)
-if _deny_read(_exe):
-    try:
-        _g = games.manual(_d)
-        check("an unreadable exe elsewhere does not mention the Xbox app",
-              _g.error and "Xbox" not in _g.error, repr(_g.error))
-    finally:
-        _allow_read(_exe)
-else:
-    check("icacls deny not available here - plain unreadable check skipped", True)
+with patch("builtins.open", side_effect=_protected_read):
+    _g = games.manual(_d)
+    check("an unreadable exe elsewhere stays fatal without an Xbox warning",
+          _g.error and not _g.exe_warning and not installer.check_supported(_g)[0],
+          repr(_g.error))
 shutil.rmtree(_d, ignore_errors=True)
 
-# preflight: a write refused under XboxGames says Enable mods, anywhere else
-# it says run as administrator.
+# preflight distinguishes a refused directory write from EXE protection.
 _d = Path(tempfile.mkdtemp(prefix="xbox_pre_"))
 _content = _d / "XboxGames" / "Fake" / "Content"
 _content.mkdir(parents=True)
@@ -1436,21 +1403,22 @@ _gx = games.manual(_content)
 _plain = Path(tempfile.mkdtemp(prefix="plain_pre_"))
 shutil.copyfile(X64, _plain / "Game.exe")
 _gp = games.manual(_plain)
-_orig_wb = Path.write_bytes
+_orig_probe = tempfile.NamedTemporaryFile
 
 
-def _refuse(self, data):
-    raise PermissionError(13, "Permission denied", str(self))
+def _refuse(*args, **kwargs):
+    raise PermissionError(13, "Permission denied", str(kwargs.get("dir")))
 
 
-Path.write_bytes = _refuse
+tempfile.NamedTemporaryFile = _refuse
 try:
     try:
         installer.preflight(_gx)
         check("preflight under XboxGames raises on a refused write", False)
     except installer.InstallError as e:
-        check("preflight under XboxGames names Enable mods, not administrator",
-              "Enable mods" in str(e) and "administrator" not in str(e), str(e)[:80])
+        check("preflight under XboxGames reports the actual write restriction",
+              games.XBOX_HINT in str(e) and "Permission denied" in str(e)
+              and "Enable mods" not in str(e) and "administrator" not in str(e), str(e)[:80])
     try:
         installer.preflight(_gp)
         check("preflight elsewhere raises on a refused write", False)
@@ -1458,7 +1426,7 @@ try:
         check("preflight elsewhere still says run as administrator",
               "administrator" in str(e) and "Xbox" not in str(e), str(e)[:80])
 finally:
-    Path.write_bytes = _orig_wb
+    tempfile.NamedTemporaryFile = _orig_probe
 try:
     installer.preflight(_gp)
     check("preflight passes again once writes work", True)
@@ -3665,7 +3633,7 @@ with _zf2.ZipFile(_dir, "w") as z:
     z.writestr("dlss5-autopilot/_internal/core/gui.pyc", b"pyc")
     z.writestr("dlss5-autopilot/README.md", "x")
 _saved = (net.json_get, net.download, net.fetch_text, selfupdate.MIN_BYTES)
-selfupdate.MIN_BYTES = 70000         # the fixture exe (65 KB) alone is below this; exe + _internal is above
+selfupdate.MIN_BYTES = len(_pe) + 4000   # exe alone is below; exe + _internal is above
 _sha = hashlib.sha256(_pe).hexdigest()
 net.fetch_text = lambda url: f"{_sha}  dist/dlss5-autopilot.exe\n".encode()
 net.json_get = lambda url: {"tag_name": "v9.9", "assets": [
@@ -3681,13 +3649,13 @@ try:
     check("the size floor applies to the exe alone for a one-file release", _raised)
     selfupdate.MIN_BYTES = 1024
     _exe1 = selfupdate.fetch()
-    selfupdate.MIN_BYTES = 70000
+    selfupdate.MIN_BYTES = len(_pe) + 4000
     check("a one-file release yields the exe alone",
           _exe1.name == "dlss5-autopilot.exe" and not (_exe1.parent / "_internal").exists())
     net.download = lambda url, name, **k: _dir
     _exe2 = selfupdate.fetch()
     check("...but for a one-folder release the whole download is measured (exe alone would fail)",
-          _exe2.stat().st_size < 70000)
+          _exe2.stat().st_size < selfupdate.MIN_BYTES)
     check("a one-folder release yields the exe WITH its _internal folder beside it",
           _exe2.name == "dlss5-autopilot.exe"
           and (_exe2.parent / "_internal" / "python313.dll").is_file()
@@ -3869,8 +3837,9 @@ try:
 finally:
     sources.urllib.request.urlopen, sources.time.sleep = _saved
 
-check("the Xbox hint no longer claims every Store game has an 'Enable mods' switch",
-      "Only games whose publisher" in games.XBOX_HINT and "Steam version" in games.XBOX_HINT)
+check("the Xbox hint distinguishes protection from write access without a mods toggle",
+      "separate" in games.XBOX_HINT and "installation cannot continue" in games.XBOX_HINT
+      and "Enable mods" not in games.XBOX_HINT)
 
 _d = Path(tempfile.mkdtemp(prefix="apiov_"))
 shutil.copyfile(X64, _d / "Game.exe")

--- a/test_scan.py
+++ b/test_scan.py
@@ -1,6 +1,7 @@
 """Offline scan regressions: python -m unittest -v test_scan."""
 import json
 import queue
+import struct
 import tempfile
 import threading
 import unittest
@@ -8,7 +9,7 @@ from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from core import dlss, games, gui, installer, log
+from core import dlss, games, gui, installer, library, log, pe, prefs
 
 
 class ScanTests(unittest.TestCase):
@@ -193,6 +194,7 @@ class ScanTests(unittest.TestCase):
         app.btn_next = Mock()
         app.status = Mock()
         app.detail = Mock()
+        app.protected_details = Mock()
         app._sm = Mock(return_value=120)
         app._check_stale = Mock()
         app.rail_rows = []
@@ -276,6 +278,200 @@ class ScanTests(unittest.TestCase):
         self.assertEqual(app.tree.insert.call_count, 2)
         self.assertEqual(app.tree.insert.call_args.kwargs["values"][-1], "unreadable")
         self.assertFalse(app.busy)
+
+
+class ProtectedXboxTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="autopilot_xbox_")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.folder = self.root / "XboxGames/Fake/Content"
+        self.folder.mkdir(parents=True)
+        self.exe = self.folder / "Game.exe"
+        # A real minimal x64 COFF header, not a mocked architecture result.
+        data = bytearray(128)
+        data[:2] = b"MZ"
+        struct.pack_into("<I", data, 0x3c, 64)
+        data[64:70] = b"PE\0\0" + struct.pack("<H", pe.PE_X64)
+        self.exe.write_bytes(data)
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        self.stack.enter_context(patch.object(prefs, "FILE", self.root / "settings.json"))
+        self.stack.enter_context(patch.object(library, "FILE", self.root / "library.json"))
+        self.stack.enter_context(patch.object(log, "write"))
+        self.stack.enter_context(patch.object(installer, "_running_processes", return_value=set()))
+
+    def protect(self):
+        read = open
+
+        def guarded(path, mode="r", *args, **kwargs):
+            if Path(path) == self.exe and mode == "rb":
+                raise PermissionError(13, "Permission denied", str(path))
+            return read(path, mode, *args, **kwargs)
+
+        self.stack.enter_context(patch("builtins.open", side_effect=guarded))
+
+    def test_readable_x64_ignores_architecture_override_and_clears_stale_metadata(self):
+        games.set_bitness_override(self.folder, 32)
+        g = games.manual(self.folder)
+        self.assertEqual(g.bitness, 64)
+        self.assertFalse(g.error or g.exe_warning)
+        self.assertTrue(installer.check_supported(g)[0])
+        g.error, g.exe_warning = "old error", games.XBOX_EXE_HINT
+        g.bitness, g.api = 32, "DX9"
+        games.enrich(g)
+        self.assertFalse(g.error or g.exe_warning)
+        self.assertEqual((g.bitness, g.api), (64, pe.detect_api(self.exe)[0]))
+
+    def test_protected_executable_needs_both_overrides_to_be_supported(self):
+        self.protect()
+        g = games.manual(self.folder)
+        self.assertEqual(g.exe, self.exe)
+        self.assertEqual(g.exe_warning, games.XBOX_EXE_HINT)
+        self.assertFalse(g.error)
+        self.assertIsNone(g.bitness)
+        ok, why = installer.check_supported(g)
+        self.assertFalse(ok)
+        self.assertIn("select its architecture and graphics API", why)
+        games.set_bitness_override(self.folder, 64)
+        games.enrich(g)
+        self.assertFalse(installer.check_supported(g)[0], "unknown API must not be assumed")
+        games.set_api_override(self.folder, "DX12")
+        games.enrich(g)
+        self.assertEqual((g.bitness, g.api), (64, "DX12"))
+        self.assertTrue(installer.check_supported(g)[0])
+        self.assertIn(g.exe_warning, installer.preview(g, installer.Options()).warnings)
+
+    def test_api_detection_can_use_adjacent_files(self):
+        self.protect()
+        games.set_bitness_override(self.folder, 64)
+        sdk = self.folder / "D3D12/D3D12Core.dll"
+        sdk.parent.mkdir()
+        sdk.touch()
+        g = games.manual(self.folder)
+        self.assertEqual((g.bitness, g.api), (64, "DX12"))
+        self.assertIn("Agility", g.api_why)
+        self.assertTrue(installer.check_supported(g)[0])
+
+    def test_preflight_writes_beside_protected_exe_and_preserves_existing_file(self):
+        self.protect()
+        existing = self.folder / ".dlss5-autopilot-write-test"
+        existing.write_bytes(b"keep me")
+        before = set(self.folder.iterdir())
+        installer.preflight(games.manual(self.folder))
+        self.assertEqual(set(self.folder.iterdir()), before)
+        self.assertEqual(existing.read_bytes(), b"keep me")
+
+    def test_denied_directory_blocks_preflight_and_install(self):
+        self.protect()
+        games.set_bitness_override(self.folder, 64)
+        games.set_api_override(self.folder, "DX12")
+        g = games.manual(self.folder)
+        before = set(self.folder.iterdir())
+        with patch.object(installer.tempfile, "NamedTemporaryFile",
+                          side_effect=PermissionError(13, "Permission denied")):
+            for action in (lambda: installer.preflight(g),
+                           lambda: installer.install(g, installer.Options())):
+                with self.assertRaises(installer.InstallError) as cm:
+                    action()
+                self.assertIn(str(g.install_dir), str(cm.exception))
+                self.assertIn("installation cannot continue", str(cm.exception))
+                self.assertNotIn("Enable mods", str(cm.exception))
+        self.assertEqual(set(self.folder.iterdir()), before)
+
+    def test_invalid_architecture_overrides_are_rejected_and_ignored(self):
+        for value in (0, 16, 128, "64", 64.0, True, [], {}):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    games.set_bitness_override(self.folder, value)
+                prefs.set_("bitness_override", {str(self.folder).lower(): value})
+                self.assertIsNone(games.bitness_override(self.folder))
+        prefs.set_("bitness_override", [64])
+        self.assertIsNone(games.bitness_override(self.folder))
+
+    def test_preferences_and_cache_round_trip_and_override_removal(self):
+        self.protect()
+        games.set_bitness_override(self.folder, 64)
+        games.set_api_override(self.folder, "DX12")
+        g = games.manual(self.folder)
+        key = (str(g.folder), str(g.exe))
+        library.save([g], {key: gui.App._inspect_row(g, 89)}, "test", 89)
+        cached, rows, changed = library.load("test", 89)
+        self.assertEqual((cached[0].bitness, cached[0].api), (64, "DX12"))
+        self.assertEqual(cached[0].exe_warning, games.XBOX_EXE_HINT)
+        self.assertFalse(cached[0].error)
+        self.assertEqual(changed, cached)
+        self.assertNotIn(key, rows)
+        games.set_bitness_override(self.folder, None)
+        games.set_api_override(self.folder, None)
+        cached, _, _ = library.load("test", 89)
+        self.assertIsNone(cached[0].bitness)
+        self.assertEqual(cached[0].api, g.api_detected)
+        self.assertFalse(installer.check_supported(cached[0])[0])
+
+    def test_non_xbox_permission_error_stays_fatal_despite_overrides(self):
+        plain = self.root / "Plain"
+        plain.mkdir()
+        self.exe = self.exe.rename(plain / "Game.exe")
+        self.protect()
+        games.set_bitness_override(plain, 64)
+        games.set_api_override(plain, "DX12")
+        g = games.manual(plain)
+        self.assertTrue(g.error)
+        self.assertFalse(g.exe_warning)
+        self.assertFalse(installer.check_supported(g)[0])
+
+    def test_corrupt_readable_xbox_exe_stays_fatal(self):
+        self.exe.write_bytes(b"not a PE")
+        games.set_bitness_override(self.folder, 64)
+        games.set_api_override(self.folder, "DX12")
+        g = games.manual(self.folder)
+        self.assertTrue(g.error)
+        self.assertFalse(g.exe_warning)
+        self.assertFalse(installer.check_supported(g)[0])
+
+    def test_gui_metadata_choices_refresh_status_and_navigation(self):
+        self.protect()
+        with patch.object(gui.App, "_check_update"):
+            root = gui.tk.Tk()
+            self.addCleanup(root.destroy)
+            root.withdraw()
+            app = gui.App(root)
+        failures = []
+        root.report_callback_exception = lambda *args: failures.append(args)
+        g = games.manual(self.folder)
+        app.all_games = [g]
+        app._show(2)
+        app._fill()
+        app.tree.selection_set("0")
+        app._on_pick()
+        self.assertEqual(app.protected_details.winfo_manager(), "pack")
+        self.assertEqual(app.tree.item("0", "values")[-1], "needs metadata")
+        app._next()   # double-click cannot bypass the disabled button
+        self.assertEqual(app.step, 2)
+        app.cb_bitness.current(1)
+        app.cb_bitness.event_generate("<<ComboboxSelected>>")
+        self.assertEqual(g.bitness, 64)
+        self.assertEqual(str(app.btn_next["state"]), "disabled")
+        app.cb_protected_api.current(games.APIS.index("DX12") + 1)
+        app.cb_protected_api.event_generate("<<ComboboxSelected>>")
+        self.assertEqual(g.api, "DX12")
+        self.assertEqual(app.tree.item("0", "values")[-1], "ready")
+        self.assertEqual(str(app.btn_next["state"]), "normal")
+        with patch.object(app, "_enter_install") as enter:
+            app._next()
+            enter.assert_called_once()
+        self.assertEqual(app.step, 3)
+        app._show(2)
+        app.cb_bitness.current(0)
+        app.cb_bitness.event_generate("<<ComboboxSelected>>")
+        self.assertIsNone(g.bitness)
+        self.assertFalse(app._can_install_page())
+        g.exe_warning = ""
+        g.bitness = 64
+        app._on_pick()
+        self.assertEqual(app.protected_details.winfo_manager(), "")
+        self.assertEqual(failures, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #71.

Some Xbox games protect their executable from reading even when the install directory is writable. This is the case with FH6's Content/ directory.

Protected executables now allow manual architecture selection and reuse the existing graphics API override. The protection warning remains visible, but games with the required metadata can reach the install page.

The normal installer preflight still blocks installation if Windows denies directory writes. No ownership or ACL changes are made.

Validation:
- Tested FH6 with manual 64-bit / DX12 overrides and neural upstream; no issues observed.
- Full test suite passes.
- Added 10 focused regression tests.